### PR TITLE
fix(scripts): size split chunks by written output

### DIFF
--- a/scripts/split_json.py
+++ b/scripts/split_json.py
@@ -4,6 +4,21 @@ import argparse
 import json
 import tempfile
 from pathlib import Path
+from textwrap import indent
+
+DOCUMENT_PREFIX = '{\n  "data_list": [\n'
+DOCUMENT_SUFFIX = "\n  ]\n}\n"
+ITEM_SEPARATOR = ",\n"
+ITEM_INDENT = "    "
+
+
+def render_item(item: object) -> str:
+    """Render one data_list element as it appears inside the split document."""
+    return indent(json.dumps(item, indent=2), ITEM_INDENT)
+
+
+def render_document(rendered: list[str]) -> str:
+    return DOCUMENT_PREFIX + ITEM_SEPARATOR.join(rendered) + DOCUMENT_SUFFIX
 
 
 def split_file(source: Path, max_bytes: int) -> list[Path]:
@@ -14,17 +29,27 @@ def split_file(source: Path, max_bytes: int) -> list[Path]:
     if not isinstance(items, list) or not items:
         raise ValueError("input must contain a non-empty data_list array")
 
+    # json.dumps escapes non-ASCII by default, so a rendered length in characters
+    # equals its UTF-8 byte count. Chunk sizing below relies on that equality.
+    overhead = len(DOCUMENT_PREFIX) + len(DOCUMENT_SUFFIX)
     target = max(max_bytes * 80 // 100, 1)
-    chunks: list[list[object]] = []
-    current: list[object] = []
-    current_size = 0
-    for item in items:
-        item_size = len(json.dumps(item, separators=(",", ":")).encode()) + 1
+    chunks: list[list[str]] = []
+    current: list[str] = []
+    current_size = overhead
+    for index, item in enumerate(items):
+        rendered = render_item(item)
+        item_size = len(rendered) + (len(ITEM_SEPARATOR) if current else 0)
+        if not current and overhead + len(rendered) > max_bytes:
+            raise ValueError(
+                f"{source}: data_list item {index} does not fit in a chunk of "
+                f"{max_bytes} bytes"
+            )
         if current and current_size + item_size > target:
             chunks.append(current)
             current = []
-            current_size = 0
-        current.append(item)
+            current_size = overhead
+            item_size = len(rendered)
+        current.append(rendered)
         current_size += item_size
     chunks.append(current)
 
@@ -33,12 +58,16 @@ def split_file(source: Path, max_bytes: int) -> list[Path]:
         for index, chunk in enumerate(chunks):
             output = source.with_name(f"{source.stem}_{index}.json")
             with tempfile.NamedTemporaryFile(
-                "w", dir=source.parent, encoding="utf-8", delete=False
+                "w", dir=source.parent, encoding="utf-8", delete=False, newline="\n"
             ) as temporary:
-                json.dump({"data_list": chunk}, temporary, indent=2)
-                temporary.write("\n")
+                temporary.write(render_document(chunk))
             Path(temporary.name).replace(output)
             outputs.append(output)
+            written = output.stat().st_size
+            if written > max_bytes:
+                raise ValueError(
+                    f"{output}: chunk is {written} bytes, above the {max_bytes} byte limit"
+                )
     except Exception:
         for output in outputs:
             output.unlink(missing_ok=True)


### PR DESCRIPTION
Fixes the recurring `Update Japan Version` failure ([run 32963939203](https://github.com/arisu-archive/bluearchive-data/actions/runs/32963939203)).

Why: `split_file` measured each `data_list` item with compact separators (`json.dumps(item, separators=(",", ":"))`) but wrote chunks with `indent=2`. Pretty-printing inflated the output ~1.4x over the measured budget, so a chunk targeted at 80 MiB was written at 102.75 MB and the push was rejected:

```
remote: error: File ExcelDB/ScenarioScriptExcel_0.json is 102.75 MB; this exceeds GitHub's file size limit of 100.00 MB
remote: error: GH001: Large files detected
! [remote rejected] ... (pre-receive hook declined)
```

What:
* Measurement and writing share one renderer (`render_item` / `render_document`), so the two cannot drift again.
* Each chunk is re-checked against the limit after it is written; a violation raises and cleans up instead of leaving an oversized file.
* An item too large to fit in a chunk on its own now fails with a named file and index rather than being emitted oversized.
* Chunk accounting stays O(n) over the item list.

Local verification (scaled to 1 MiB limits; the defect is ratio-based, so it reproduces at any scale):
* Before: `big_0.json` = 1,172,758 B against a 1,048,576 B limit -> reproduces the CI failure.
* After: chunks 838,764 / 838,584 / 240,504 B, all within budget.
* Output is byte-identical in format to the previous `json.dump(..., indent=2)` writer, so committed files keep their current shape.
* Round-trip is lossless, including non-ASCII payloads; the source file is still removed after splitting.
* Oversized-single-item and empty-`data_list` inputs raise and leave no partial output.